### PR TITLE
Remove duplicate wp_footer() and HTML tags

### DIFF
--- a/templates/footer.php
+++ b/templates/footer.php
@@ -23,8 +23,3 @@
 		); ?>
 	</footer><!-- .content-info -->
 </div><!-- #page -->
-
-<?php wp_footer(); ?>
-
-</body>
-</html>


### PR DESCRIPTION
This code is already output in the `base.php` and `footer-wp-signup.php` templates. As is, the `wp_footer` action fires twice and `</body></html`> is output twice.